### PR TITLE
squid:S2039 - Member variable visibility should be specified

### DIFF
--- a/app/src/main/java/cuneyt/example/com/tagview/Activity/MainActivity.java
+++ b/app/src/main/java/cuneyt/example/com/tagview/Activity/MainActivity.java
@@ -28,15 +28,15 @@ import cuneyt.example.com.tagview.Models.TagClass;
 
 public class MainActivity extends AppCompatActivity {
 
-    TagView tagGroup;
+    private TagView tagGroup;
 
-    EditText editText;
+    private EditText editText;
 
 
     /**
      * sample country list
      */
-    ArrayList<TagClass> tagList;
+    private ArrayList<TagClass> tagList;
 
 
     @Override

--- a/app/src/main/java/cuneyt/example/com/tagview/Models/TagClass.java
+++ b/app/src/main/java/cuneyt/example/com/tagview/Models/TagClass.java
@@ -10,9 +10,9 @@ import java.util.Random;
  */
 public class TagClass {
 
-    String code;
-    String name;
-    String color;
+    private String code;
+    private String name;
+    private String color;
 
     public TagClass() {
 

--- a/library/src/main/java/com/cunoraz/tagview/TagView.java
+++ b/library/src/main/java/com/cunoraz/tagview/TagView.java
@@ -51,12 +51,12 @@ public class TagView extends RelativeLayout {
     /**
      * custom layout param
      */
-    int lineMargin;
-    int tagMargin;
-    int textPaddingLeft;
-    int textPaddingRight;
-    int textPaddingTop;
-    int texPaddingBottom;
+    private int lineMargin;
+    private int tagMargin;
+    private int textPaddingLeft;
+    private int textPaddingRight;
+    private int textPaddingTop;
+    private int texPaddingBottom;
 
 
     /**


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2039 - Member variable visibility should be specified

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2039

Please let me know if you have any questions.

M-Ezzat